### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "start"

--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 This is the finished code from a tutorial that I wrote about saving data to a MongoDB database from a Node.js Application. You can read the tutorial to get step-by-step instructions on how to save data to a MongoDB database.
 
 [You can read the tutorial here](http://www.jenniferbland.com/saving-data-to-mongodb-database-from-node-js-application-tutorial/)
+
+[![Run on Repl.it](https://repl.it/badge/github/ratracegrad/node-mongo-demo)](https://repl.it/github/ratracegrad/node-mongo-demo)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ricardostagle/node-mongo-demo).